### PR TITLE
openDevTools: pass object with mode key instead of string

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -70,7 +70,7 @@ function createWindow() {
     // not very useful anyway
     if(args.debug) {
         // Open the DevTools.
-        mainWindow.webContents.openDevTools('bottom');
+        mainWindow.webContents.openDevTools({ mode: 'bottom' });
     }
 
     mainWindow.webContents.on('did-finish-load', function() {


### PR DESCRIPTION
My guess is that Electron never supported a string argument, but silently ignored it in the past? But now Electron throws an error. This patch fixes it.

Fixes #23